### PR TITLE
move block_reduce_warp_reductions.cuh include out of tc_utils.cuh again

### DIFF
--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -33,15 +33,15 @@
 
 #pragma once
 
-// #include "specializations/block_reduce_raking.cuh"
-// #include "specializations/block_reduce_raking_commutative_only.cuh"
-// #include "specializations/block_reduce_warp_reductions.cuh"
-// #include "../util_ptx.cuh"
-// #include "../util_type.cuh"
-// #include "../thread/thread_operators.cuh"
-// #include "../util_namespace.cuh"
-
 #include "../tc_utils.cuh"
+
+#include "specializations/block_reduce_raking.cuh"
+#include "specializations/block_reduce_raking_commutative_only.cuh"
+#include "specializations/block_reduce_warp_reductions.cuh"
+#include "../util_ptx.cuh"
+#include "../util_type.cuh"
+#include "../thread/thread_operators.cuh"
+#include "../util_namespace.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX

--- a/cub/tc_utils.cuh
+++ b/cub/tc_utils.cuh
@@ -83,7 +83,3 @@ template<typename _Tp>
 
 #include "warp/specializations/warp_reduce_shfl.cuh"
 #include "warp/specializations/warp_reduce_smem.cuh"
-
-// #include "block/specializations/block_reduce_raking.cuh"
-// #include "block/specializations/block_reduce_raking_commutative_only.cuh"
-#include "block/specializations/block_reduce_warp_reductions.cuh"


### PR DESCRIPTION
Among many other changes, 5fe279d2 (BlockReduce + NVRTC, Wed Jan 17 10:03:19 2018 -0800) moved the specializations/block_reduce_warp_reductions.cuh include from block/block_reduce.cuh to tc_utils.cuh without a clear motivation.

This makes warp/warp_reduce.cuh, which also includes tc_utils.cuh, unusable because the tc_utils.cuh include inside warp/warp_reduce.cuh happens before WarpReduce is defined, while
specializations/block_reduce_warp_reductions.cuh requires it to be defined. (The include of warp/warp_reduce.cuh inside specializations/block_reduce_warp_reductions.cuh gets skipped because warp/warp_reduce.cuh is already being processed.)

Move the include back to block/block_reduce.cuh. 

However, do it after the include of tc_utils.cuh such that the changes in 5fe279d2 to tc_utils.cuh get picked up.